### PR TITLE
fix: Add commas to fix install_requires error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages('src'),
     python_requires=">=3.6",
     install_requires=[
-        'aiohttp>=3.8.1<4.0.0'
-        'httpx>=0.20.0<1.0.0',
+        'aiohttp>=3.8.1,<4.0.0',
+        'httpx>=0.20.0,<1.0.0'
     ],
 )


### PR DESCRIPTION
Fix the following error:

```
Installation error: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```